### PR TITLE
fix: はみ出ないようにボタンを横並びに修正

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -155,17 +155,18 @@
         </div>
       </fieldset>
       <h1>モード選択</h1>
-      <div class="mode-button">
-        <button class="it-button" data-action="game-it">
-          IT用語のタイピング
-        </button>
+      <div class="mode-buttons">
+        <div class="mode-button">
+          <button class="it-button" data-action="game-it">
+            IT用語のタイピング
+          </button>
+        </div>
+        <div class="mode-button">
+          <button class="normal-button" data-action="game-normal">
+            ノーマルタイピング
+          </button>
+        </div>
       </div>
-      <div class="mode-button">
-        <button class="normal-button" data-action="game-normal">
-          ノーマルタイピング
-        </button>
-      </div>
-
       <button data-action="back" class="backButton" alt="back" value="back">
         戻る
       </button>

--- a/public/stylesheets/select-mode.css
+++ b/public/stylesheets/select-mode.css
@@ -3,9 +3,8 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: space-evenly;
   align-items: center;
-  gap: 2rem;
 }
 
 [data-screen="select-mode"] h1 {
@@ -19,7 +18,6 @@
   justify-content: space-around;
   align-items: center;
   padding: 1rem;
-  border: 100%;
   font-size: 2rem;
   text-align: center;
   color: #fff;
@@ -50,11 +48,16 @@
 [data-screen="select-mode"] .radio-group input[type="radio"] {
   transform: scale(2);
 }
+.mode-buttons {
+  display: flex;
+  gap: 1rem;
+}
 
 .mode-button button {
   border: 0;
   line-height: 2.5;
-  width: 600px;
+  width: 100%;
+  max-width: 600px;
   padding: 0 2rem;
   font-size: 2rem;
   text-align: center;
@@ -134,7 +137,6 @@ input[type="radio"] {
   justify-content: space-around;
   align-items: center;
   padding: 1rem;
-  border: 100%;
   font-size: 2rem;
   text-align: center;
   color: #000000;


### PR DESCRIPTION
Closes #70  <!-- 関連するイシュー番号があれば書く（例：#0） -->

## 概要

MacBookなどで縦幅がはみ出ないようにボタンを横並びにして修正

<img width="1437" alt="image" src="https://github.com/user-attachments/assets/10f456a2-7801-46eb-a808-5a82a6e98187">


## 変更点

<!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->

## 追加情報

<!-- その他で記述する情報があれば書いてください -->
